### PR TITLE
refactor(frontend): consolidate wishlist cover image logic

### DIFF
--- a/frontend/src/components/Wishlist.tsx
+++ b/frontend/src/components/Wishlist.tsx
@@ -12,9 +12,10 @@ import { DndContext } from "@dnd-kit/core";
 
 import { SortableContext } from "@dnd-kit/sortable";
 import { SortableItem } from "./ui/SortableItem";
-import { useWishlists, WishlistItemType, WishlistType } from "../hooks/useWishlists";
+import { useWishlists, WishlistType } from "../hooks/useWishlists";
 import { useWishlistDnd } from "../hooks/useWishlistDnd";
 import { useShareLink } from "../hooks/useShareLink";
+import { getWishlistCoverImage } from "../shared/lib/getWishlistCoverImage";
 
 const fallbackCoverImage =
   "https://images.unsplash.com/photo-1647221598091-880219fa2c8f?q=80&w=2232&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
@@ -116,22 +117,10 @@ const Wishlist = () => {
                         );
                       }
 
-                      const highestOrderedItemWithImage = items.reduce<WishlistItemType | null>(
-                        (best, item) => {
-                          if (!item.imageUrl) return best;
-
-                          if (!best) return item;
-
-                          const bestOrder = best.order ?? 0;
-                          const itemOrder = item.order ?? 0;
-
-                          return itemOrder > bestOrder ? item : best;
-                        },
-                        null
-                      );
-
-                      const coverImageUrl =
-                        highestOrderedItemWithImage?.imageUrl || fallbackCoverImage;
+                      const coverImageUrl = getWishlistCoverImage({
+                        items,
+                        fallbackImage: fallbackCoverImage,
+                      });
 
                       return (
                         <WishlistCard

--- a/frontend/src/pages/WishlistDetails.tsx
+++ b/frontend/src/pages/WishlistDetails.tsx
@@ -15,6 +15,7 @@ import NotFound from "./NotFound";
 import { useWishlistDetails, isValidGuid, WishlistDetailsItemType } from "../hooks/useWishlistDetails";
 import { useWishlistItemsDnd } from "../hooks/useWishlistItemsDnd";
 import { useShareLink } from "../hooks/useShareLink";
+import { getWishlistCoverImage } from "../shared/lib/getWishlistCoverImage";
 
 const WishlistDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -68,25 +69,11 @@ const WishlistDetail = () => {
   const fallbackCoverImage =
     "https://images.unsplash.com/photo-1647221598091-880219fa2c8f?q=80&w=2232&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
 
-  // Pick item with the highest `order` that has an image
-  const highestOrderedItemWithImage = items.reduce<WishlistDetailsItemType | null>(
-    (best, item) => {
-      if (!item.imageUrl) return best; // skip items without image
-
-      if (!best) return item; // first candidate
-
-      const bestOrder = best.order ?? 0;
-      const itemOrder = item.order ?? 0;
-
-      return itemOrder > bestOrder ? item : best;
-    },
-    null
-  );
-
-  const coverImageUrl =
-    wishlist.coverImage ||
-    highestOrderedItemWithImage?.imageUrl ||
-    fallbackCoverImage;
+  const coverImageUrl = getWishlistCoverImage<WishlistDetailsItemType>({
+    items,
+    fallbackImage: fallbackCoverImage,
+    wishlistCoverImage: wishlist.coverImage,
+  });
 
   return (
     <>

--- a/frontend/src/shared/lib/getWishlistCoverImage.ts
+++ b/frontend/src/shared/lib/getWishlistCoverImage.ts
@@ -1,0 +1,37 @@
+type WishlistCoverImageItem = {
+  imageUrl?: string | null;
+  order?: number | null;
+};
+
+type GetWishlistCoverImageOptions<T extends WishlistCoverImageItem> = {
+  items?: T[] | null;
+  fallbackImage: string;
+  wishlistCoverImage?: string | null;
+};
+
+export const getWishlistCoverImage = <T extends WishlistCoverImageItem>({
+  items,
+  fallbackImage,
+  wishlistCoverImage,
+}: GetWishlistCoverImageOptions<T>): string => {
+  if (wishlistCoverImage) {
+    return wishlistCoverImage;
+  }
+
+  if (!items || items.length === 0) {
+    return fallbackImage;
+  }
+
+  const highestOrderedItemWithImage = items.reduce<T | null>((best, item) => {
+    if (!item.imageUrl) return best;
+
+    if (!best) return item;
+
+    const bestOrder = best.order ?? 0;
+    const itemOrder = item.order ?? 0;
+
+    return itemOrder > bestOrder ? item : best;
+  }, null);
+
+  return highestOrderedItemWithImage?.imageUrl || fallbackImage;
+};


### PR DESCRIPTION
## Summary\n- extract shared wishlist cover image selector to frontend/src/shared/lib/getWishlistCoverImage.ts\n- reuse the helper in wishlist list and details views to keep selection behavior consistent