### PR TITLE
refactor(frontend): clean up auth context ownership

### DIFF
--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -14,8 +14,6 @@ import { useDatabaseUser } from "../hooks/useDatabaseUser";
 import { useFirebaseAuth } from "../hooks/useFirebaseAuth";
 import { AuthContext } from "../context/AuthContext";
 
-export { AuthContext };
-
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const { firebaseUser, loading, refreshFirebaseUser, clearFirebaseUser } = useFirebaseAuth();
   const {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { AuthContext } from "../components/AuthProvider";
+import { AuthContext } from "../context/AuthContext";
 
 export const useAuth = () => {
   const context = useContext(AuthContext);


### PR DESCRIPTION
## Summary
- Move AuthContext import in useAuth to the dedicated context module
- Stop re-exporting AuthContext from AuthProvider to keep Fast Refresh boundaries clean

## Testing
- make frontend-lint (warnings in existing files)
- make frontend-typecheck
- make frontend-build